### PR TITLE
Update mabox-gl-native to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,34 @@
-FROM node:6-stretch as build
+FROM ubuntu:18.04 as build
 
 RUN apt-get -qq update \
 && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-   curl git build-essential zlib1g-dev automake \
-   libtool xutils-dev make cmake pkg-config python-pip \
-   libcurl4-openssl-dev libpng-dev libsqlite3-dev \
-   libllvm3.9 libglfw3 libgles2-mesa-dev \
-   libgbm-dev libxxf86vm-dev xvfb
+  curl git build-essential zlib1g-dev automake \
+  libtool xutils-dev make pkg-config python-pip \
+  libcurl4-openssl-dev libpng-dev libsqlite3-dev \
+  libllvm3.9 libglfw3 libgles2-mesa-dev \
+  libgbm-dev libxxf86vm-dev xvfb \
+  libxi-dev libglu1-mesa-dev x11proto-randr-dev \
+  x11proto-xext-dev libxrandr-dev \
+  x11proto-xf86vidmode-dev libxxf86vm-dev \
+  libxcursor-dev libxinerama-dev cmake ca-certificates
+
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash && apt-get -yq install nodejs
 
 RUN mkdir /build && cd /build && git clone https://github.com/mapbox/mapbox-gl-native.git \
-   && cd /build/mapbox-gl-native \
-   && git checkout 73d980a6e7ac47f04386f72405a271c8db5a337c \
-   && export BUILDTYPE=Release && make render
+  && cd /build/mapbox-gl-native \
+  && git checkout 6bb1e977eafc61af39d47df083bb3de13205fae9\
+  && export BUILDTYPE=Release && make render
 
 FROM debian:stretch
 VOLUME /data
 
 RUN apt-get -qq update \
 && DEBIAN_FRONTEND=noninteractive apt-get -y install \
-   libcurl4-openssl-dev \
-   libgles2-mesa-dev libgbm-dev libxxf86vm-dev xvfb
+  libcurl4-openssl-dev \
+  libgles2-mesa-dev libgbm-dev libxxf86vm-dev xvfb
 
 COPY --from=build /build/mapbox-gl-native/build/linux-x86_64/Release/mbgl-render /usr/local/bin/mbgl-render
-COPY --from=build /build/mapbox-gl-native/common/ca-bundle.crt /usr/local/bin/ca-bundle.crt
+COPY --from=build /build/mapbox-gl-native/misc/ca-bundle.crt /usr/local/bin/ca-bundle.crt
 COPY ./docker-entrypoint.sh /usr/local/bin/
 COPY ./thumbnails.sh /usr/local/bin/
 WORKDIR /usr/local/bin


### PR DESCRIPTION
To fit our latest style needs we have to update mapbox gl native.

We have proceed on some change to make it work. 
I hope it will help you for your futures needs

Thank's 

Update mabox-gl-native to latest (6bb1e977eafc61af39d47df083bb3de13205fae9 Nov 21, 2018) 
Replace docker image from node 6 to ubuntu 18.04
Add node 8